### PR TITLE
Add support for [fileWithoutExt] and [ext] placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # brotli plugin for webpack
 
 This plugin compresses assets with [Brotli](https://github.com/google/brotli) compression algorithm using [iltorb](https://github.com/MayhemYDG/iltorb#brotliparams) library for serving it with [ngx_brotli](https://github.com/google/ngx_brotli) or such.
- 
+
 ## Installation
 
 ```
@@ -26,7 +26,12 @@ module.exports = {
 
 Arguments:
 
-* `asset`: The target asset name. `[file]` is replaced with the original asset file name. `[path]` is replaced with the path of the original asset and `[query]` with the query. Defaults to `'[path].br[query]'`.
+* `asset`: The target asset name. Defaults to `'[path].br[query]'`.
+  * `[file]` is replaced with the original asset file name.
+  * `[fileWithoutExt]` is replaced with the file name minus its extension, e.g. the `style` of `style.css`.
+  * `[ext]` is replaced with the file name extension, e.g. the `css` of `style.css`.
+  * `[path]` is replaced with the path of the original asset.
+  * `[query]` is replaced with the query.
 * `test`: All assets matching this RegExp are processed. Defaults to every asset.
 * `threshold`: Only assets bigger than this size (in bytes) are processed. Defaults to `0`.
 * `minRatio`: Only assets that compress better that this ratio are processed. Defaults to `0.8`.

--- a/index.js
+++ b/index.js
@@ -64,11 +64,13 @@ CompressionPlugin.prototype.apply = function (compiler) {
                     var parse = url.parse(file);
                     var sub = {
                         file: file,
+                        fileWithoutExt: file.split('.').slice(0, -1).join('.'),
+                        ext: file.split('.').slice(-1).join(''),
                         path: parse.pathname,
                         query: parse.query || ''
                     };
 
-                    var newFile = this.asset.replace(/\[(file|path|query)\]/g, function (p0, p1) {
+                    var newFile = this.asset.replace(/\[(file|fileWithoutExt|ext|path|query)]/g, function (p0, p1) {
                         return sub[p1];
                     });
 


### PR DESCRIPTION
Hello,

This PR allows slightly more fine-grained control over output filenames, aiding those who use additional tooling such as S3 uploaders that infer Content-Type from file extension.

For example, an asset mapping such as ~~[root].br.[ext]~~ `[fileWithoutExt].br.[ext]` would transform `style.css` into `style.br.css`.

Thank you for creating and maintaining this useful plugin!