### PR TITLE
Optional dependencies and brotli.js fallback

### DIFF
--- a/compress.js
+++ b/compress.js
@@ -1,0 +1,18 @@
+function adapter() {
+    try {
+        var iltorb = require('iltorb');
+        return iltorb.compress;
+    } catch (err) {
+        try {
+            var brotli = require('brotli');
+            return function (content, options, callback) {
+                var result = brotli.compress(content, options);
+                callback(null, result);
+            }
+        } catch (err) {
+            throw new Error('iltorb or brotli not found. See https://github.com/mynameiswhm/brotli-webpack-plugin for details.');
+        }
+    }
+}
+
+module.exports = adapter;

--- a/index.js
+++ b/index.js
@@ -10,11 +10,7 @@ function CompressionPlugin(options) {
     this.threshold = options.threshold || 0;
     this.minRatio = options.minRatio || 0.8;
 
-    try {
-        var brotli = require('iltorb');
-    } catch (err) {
-        throw new Error('iltorb not found');
-    }
+    var compress = require('./compress.js')();
 
     var brotliOptions = {
         mode: options.hasOwnProperty('mode') ? options.mode : 0,
@@ -28,7 +24,7 @@ function CompressionPlugin(options) {
     };
 
     this.compress = function (content, callback) {
-        brotli.compress(content, brotliOptions, callback);
+        compress(content, brotliOptions, callback);
     };
 }
 module.exports = CompressionPlugin;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brotli-webpack-plugin",
-  "version": "0.2.0",
+  "version": "0.3.0-beta.0",
   "author": {
     "name": "Ilia Saulenko",
     "email": "hi@mynameiswhm.ru",
@@ -9,8 +9,11 @@
   "description": "Prepare Brotli-compressed versions of assets to serve them with Content-Encoding: br",
   "dependencies": {
     "async": "0.2.x",
-    "iltorb": "^1.0.12",
     "webpack-sources": "^0.1.0"
+  },
+  "optionalDependencies": {
+    "brotli": "^1.3.1",
+    "iltorb": "^1.0.12"
   },
   "homepage": "https://github.com/mynameiswhm/brotli-webpack-plugin",
   "repository": {


### PR DESCRIPTION
Fixes #3.

Moved `dependencies` to `optionalDependencies` and added conditional fallback to [brotli.js](https://github.com/devongovett/brotli.js)