### PR TITLE
update iltorb

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "optionalDependencies": {
     "brotli": "^1.3.1",
-    "iltorb": "^1.0.12"
+    "iltorb": "^2.0.1"
   },
   "homepage": "https://github.com/mynameiswhm/brotli-webpack-plugin",
   "repository": {


### PR DESCRIPTION
Updates the iltorb dependency to the latest major release which includes:
- addressing some issues around pre-compiled binaries (systems with older glibc or using musl)
- updating from brotli v0.6.0 to v1.0.1