### PR TITLE
Fix: Use safe compilation hooks to prevent deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+### 1.1.1
+Add safe compilation hoks to prevent deprecation warning for frozen compilation assets in Webpack 5, along with backwards compatibility for older Webpack versions.
+
 ### 1.1.0
 Added native brotli support via [zlib.brotliCompressSync](https://nodejs.org/api/zlib.html#zlib_zlib_brotlicompress_buffer_options_callback) for Node v11.7+.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brotli-webpack-plugin",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": {
     "name": "Ilia Saulenko",
     "email": "hi@mynameiswhm.ru",


### PR DESCRIPTION
I was working on improving my Webpack build performance and faced this warning, just took a look at `brotli-webpack-plugin` source codes and had it fixed by putting it in the right compilation stage. 
```
95% emitting emit BrotliPlugin(node:438254) [DEP_WEBPACK_COMPILATION_ASSETS] DeprecationWarning: Compilation.assets will be frozen in future, all modifications are deprecated.
BREAKING CHANGE: No more changes should happen to Compilation.assets after sealing the Compilation.
        Do changes to assets earlier, e. g. in Compilation.hooks.processAssets.
        Make sure to select an appropriate stage from Compilation.PROCESS_ASSETS_STAGE_*.
(Use `node --trace-deprecation ...` to show where the warning was created)
```
Also, kept old codes in case someone uses this plugin with older versions of Webpack to make sure this breaks nothing.